### PR TITLE
Teamdrives

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ To enable integration with the Drive UI, including the sharing dialog, perform t
 - Click **Enable API**
 - Select the **Drive UI Integration** tab
 - Fill out the **Application Name** and upload at least one **Application Icon**.
-- Set the *Open URL** to `http://YOURHOST/#/edit/{ids}/?user={userId}`
-- Check the *Create With** option and set the **New URL** to `http://YOURHOST/#/edit?user={userId}`
+- Set the **Open URL** to `http://YOURHOST/#/edit/{ids}/?user={userId}`
+- Check the **Create With** option and set the **New URL** to `http://YOURHOST/#/edit?user={userId}`
+- Check the **This application works properly with files in Team Drives** option
 - Click **Save Changes**
 
 Adjust the above URLs as needed for the correct hostname or path. Localhost is currently not allowed.

--- a/src/components/drive/drive.service.js
+++ b/src/components/drive/drive.service.js
@@ -55,10 +55,12 @@ module.service('drive', ['$q', '$cacheFactory', 'googleApi', 'applicationId', fu
     return googleApi.then(function(gapi) {
       var metadataRequest = gapi.client.drive.files.get({
         fileId: fileId,
+        supportsTeamDrives: true,
         fields: DEFAULT_FIELDS
       });
       var contentRequest = gapi.client.drive.files.get({
         fileId: fileId,
+        supportsTeamDrives: true,
         alt: 'media'
       });
       return $q.all([$q.when(metadataRequest), $q.when(contentRequest)]);
@@ -97,6 +99,7 @@ module.service('drive', ['$q', '$cacheFactory', 'googleApi', 'applicationId', fu
         method: method,
         params: {
           uploadType: 'multipart',
+          supportsTeamDrives: true,
           fields: DEFAULT_FIELDS
         },
         headers: { 'Content-Type' : multipart.type },


### PR DESCRIPTION
Enable Team Drive support. Relatively low impact since none of the metadata changes affect the app. Picker/sharing support is pending updates to those APIs.